### PR TITLE
Implement strings.replacer interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ as "async_http_request". In {Upper, Lower}CamelCase, that same variable will be
 rendered as "AsyncHttpRequest". To preserve the original casing, use
 {Upper, Lower}CamelCaseKeepCaps.
 
+Varcaser implements `strings.replacer` interface, that allows to use it in any place,
+where the interface is expected.
+
 **Warning**: Although varcaser.Caser implements the golang.org/x/text/transform
   interface, the Bytes() and Transform() methods have not been tested yet.
 
@@ -64,6 +67,12 @@ need one that isn't provided here.
 
 Updates
 -------
+
+**2018-10-05**
+
+Added implementation of `strings.replacer` interface, that allows to use it
+in any place, where the interface is expected.
+
 
 **2015-11-07**
 

--- a/varcaser/caser.go
+++ b/varcaser/caser.go
@@ -2,6 +2,7 @@ package varcaser
 
 import (
 	"golang.org/x/text/transform"
+	"io"
 )
 
 // type Caser is a text transformer that takes converts a variable from one
@@ -50,4 +51,15 @@ func (c Caser) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err error
 	}
 	nDst = copy(dst, result)
 	return
+}
+
+// Replace is provided for compatibility with the strings.replacer interface.
+func (c Caser) Replace(s string) string {
+	return c.String(s)
+}
+
+// WriteString is provided for compatibility with the strings.replacer interface. Since
+// Caser has no special treatment of bytes, resulting string is converted to bytes.
+func (c Caser) WriteString(w io.Writer, s string) (n int, err error) {
+	return w.Write([]byte(c.String(s)))
 }

--- a/varcaser/stringreplacer.go
+++ b/varcaser/stringreplacer.go
@@ -1,0 +1,14 @@
+package varcaser
+
+import (
+	"io"
+)
+
+// replacer is the interface that a replacement algorithm needs to implement. Provided for compatibility with the
+// strings.replacer interface. Copied from strings.replacer: https://golang.org/src/strings/replace.go
+// It is the good way to standardize all string-replacers. The interface allows to use varcaser in any place, where
+// strings.replacer is expected.
+type replacer interface {
+	Replace(s string) string
+	WriteString(w io.Writer, s string) (n int, err error)
+}

--- a/varcaser/varcaser_test.go
+++ b/varcaser/varcaser_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"golang.org/x/text/transform"
+	"strings"
 )
 
 func AssertEqual(specimen, expected interface{}, t *testing.T) {
@@ -136,4 +137,20 @@ func TestCaserIsATransformer(t *testing.T) {
 	AssertEqual(nSrc, 20, t)
 	AssertEqual(err, transform.ErrShortDst, t)
 	AssertEqual(string(dst), "one-measley-variable", t)
+}
+
+func TestCaserReplace(t *testing.T) {
+	c := Caser{From: LowerCamelCase, To: KebabCase}
+	dst := c.Replace("oneMeasleyVariable")
+	AssertEqual(dst, "one-measley-variable", t)
+}
+
+func TestCaserWriteString(t *testing.T) {
+	c := Caser{From: LowerCamelCase, To: KebabCase}
+
+	builder := &strings.Builder{}
+	nDst, err := c.WriteString(builder, "oneMeasleyVariable")
+	AssertEqual(err, nil, t)
+	AssertEqual(nDst, 20, t)
+	AssertEqual(builder.String(), "one-measley-variable", t)
 }


### PR DESCRIPTION
# Introduction
Previous implementation of Varcaser doesn't implement `strings.replacer`. There's an internal interface in go's std-lib: [strings.replacer](https://golang.org/src/strings/replace.go). It is the good way to standardize all string-replacers.
# Problem
The implementation doesn't allow us to use Varcaser, where `strings.replacer` is expected.
# Solution
Implement the interface.
# Notes
This PR is the solution of [the issue](https://github.com/danverbraganza/varcaser/issues/2) #2 