### PR TITLE
Use pointers instead of objects to avoid copying of significant size memory pieces

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ rendered as "AsyncHttpRequest". To preserve the original casing, use
 Usage Examples
 --------------
 ```
-result := Caser{From: LowerCamelCase, To: KebabCase}.String("someInitMethod")
+result := (&Caser{From: LowerCamelCase, To: KebabCase}).String("someInitMethod")
 // "some-init-method"
 
-result := Caser{From: LowerCamelCase,
-       To: ScreamingSnakeCase}.String("myConstantVariable")
+result := (&Caser{From: LowerCamelCase,
+       To: ScreamingSnakeCase}).String("myConstantVariable")
 // "MY_CONSTANT_VARIABLE"
 
 fromCase := c, err := Detect([]string{"Abcd", "MyVar", "ThisIsMyVar"})
-// CaseConvention{
+// &CaseConvention{
 //        JoinStyle: camelJoinStyle,
 //        SubsequentCase: strings.Title,
 //        InitialCase: strings.Title
@@ -64,6 +64,11 @@ need one that isn't provided here.
 
 Updates
 -------
+
+**2018-10-05**
+
+Used pointers instead of objects to avoid copying of significant size memory pieces.
+
 
 **2015-11-07**
 

--- a/varcaser/caseconvention.go
+++ b/varcaser/caseconvention.go
@@ -12,7 +12,7 @@ type WordCase func(string) string
 // A CaseConvention is a way of writing variable names using separators and
 // casing style.
 type CaseConvention struct {
-	JoinStyle
+	*JoinStyle
 	SubsequentCase WordCase
 	InitialCase    WordCase
 	Example        string // Render the name of this case convention in itself
@@ -27,8 +27,8 @@ type JoinStyle struct {
 
 // SimpleJoinStyle creates a JoinStyle that just splits and joins by a
 // separator.
-func SimpleJoinStyle(sep string) JoinStyle {
-	return JoinStyle{
+func SimpleJoinStyle(sep string) *JoinStyle {
+	return &JoinStyle{
 		Join: func(components []string) string {
 			return strings.Join(components, sep)
 		},
@@ -40,7 +40,7 @@ func SimpleJoinStyle(sep string) JoinStyle {
 
 // JoinStyle used in CamelCase. Special casing the Split function to keep
 // acronynms together.
-var camelJoinStyle = JoinStyle{
+var camelJoinStyle = &JoinStyle{
 	Join: func(components []string) string {
 		return strings.Join(components, "")
 
@@ -95,7 +95,7 @@ var camelJoinStyle = JoinStyle{
 }
 
 // SplitWords allows CaseConvention to implement Splitter.
-func (c CaseConvention) SplitWords(s string) []string {
+func (c *CaseConvention) SplitWords(s string) []string {
 	return c.Split(s)
 }
 

--- a/varcaser/caser.go
+++ b/varcaser/caser.go
@@ -8,7 +8,7 @@ import (
 // casing convention to another.
 type Caser struct {
 	From Splitter
-	To   CaseConvention
+	To   *CaseConvention
 	transform.NopResetter
 }
 
@@ -20,7 +20,7 @@ type Splitter interface {
 
 // String returns the representation of a variable name in this Caser's To
 // CaseConvention given a variable name in this Caser's From CaseConvention.
-func (c Caser) String(s string) string {
+func (c *Caser) String(s string) string {
 	components := []string{}
 	for i, s := range c.From.SplitWords(s) {
 		if i == 0 {
@@ -35,14 +35,14 @@ func (c Caser) String(s string) string {
 // Bytes is provided for compatibility with the Transformer interface. Since
 // Caser has no special treatement of bytes, the bytes are converted to and from
 // strings.
-func (c Caser) Bytes(b []byte) []byte {
+func (c *Caser) Bytes(b []byte) []byte {
 	return []byte(c.String(string(b)))
 }
 
 // Provided for compatibility with the Transformer interface. Since Caser has no
 // special treatement of bytes, the bytes are converted to and from strings.
 // Will treat the entirity of src as ONE variable name.
-func (c Caser) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err error) {
+func (c *Caser) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err error) {
 	nSrc = len(src) // Always read all the bytes of src
 	result := c.Bytes(src)
 	if len(result) > len(dst) {

--- a/varcaser/detector.go
+++ b/varcaser/detector.go
@@ -22,7 +22,7 @@ type Detected struct {
 	Split func(string) []string
 }
 
-func (d Detected) SplitWords(s string) []string {
+func (d *Detected) SplitWords(s string) []string {
 	return d.Split(s)
 }
 
@@ -49,7 +49,7 @@ func Detect(data []string) (sp Splitter, err error) {
 		}
 	}
 
-	d := Detected{}
+	d := &Detected{}
 
 	// We have now enough information to make a determination about the
 	// separator.

--- a/varcaser/varcaser.go
+++ b/varcaser/varcaser.go
@@ -9,70 +9,70 @@ package varcaser
 
 import "strings"
 
-var LowerSnakeCase = CaseConvention{
+var LowerSnakeCase = &CaseConvention{
 	JoinStyle:      SimpleJoinStyle("_"),
 	InitialCase:    strings.ToLower,
 	SubsequentCase: strings.ToLower,
 	Example:        "lower_snake_case",
 }
 
-var ScreamingSnakeCase = CaseConvention{
+var ScreamingSnakeCase = &CaseConvention{
 	JoinStyle:      SimpleJoinStyle("_"),
 	InitialCase:    strings.ToUpper,
 	SubsequentCase: strings.ToUpper,
 	Example:        "SCREAMING_SNAKE_CASE",
 }
 
-var KebabCase = CaseConvention{
+var KebabCase = &CaseConvention{
 	JoinStyle:      SimpleJoinStyle("-"),
 	InitialCase:    strings.ToLower,
 	SubsequentCase: strings.ToLower,
 	Example:        "kebab-case",
 }
 
-var UpperKebabCase = CaseConvention{
+var UpperKebabCase = &CaseConvention{
 	JoinStyle:      SimpleJoinStyle("-"),
 	InitialCase:    ToStrictTitle,
 	SubsequentCase: ToStrictTitle,
 	Example:        "Upper-Kebab-Case",
 }
 
-var ScreamingKebabCase = CaseConvention{
+var ScreamingKebabCase = &CaseConvention{
 	JoinStyle:      SimpleJoinStyle("-"),
 	InitialCase:    strings.ToUpper,
 	SubsequentCase: strings.ToUpper,
 	Example:        "SCREAMING-KEBAB-CASE",
 }
 
-var HttpHeaderCase = CaseConvention{
+var HttpHeaderCase = &CaseConvention{
 	JoinStyle:      SimpleJoinStyle("-"),
 	InitialCase:    ToHttpTitle,
 	SubsequentCase: ToHttpTitle,
 	Example:        "HTTP-Header-Case",
 }
 
-var UpperCamelCase = CaseConvention{
+var UpperCamelCase = &CaseConvention{
 	JoinStyle:      camelJoinStyle,
 	InitialCase:    ToStrictTitle,
 	SubsequentCase: ToStrictTitle,
 	Example:        "UpperCamelCase",
 }
 
-var LowerCamelCase = CaseConvention{
+var LowerCamelCase = &CaseConvention{
 	JoinStyle:      camelJoinStyle,
 	InitialCase:    strings.ToLower,
 	SubsequentCase: ToStrictTitle,
 	Example:        "lowerCamelCase",
 }
 
-var UpperCamelCaseKeepCaps = CaseConvention{
+var UpperCamelCaseKeepCaps = &CaseConvention{
 	JoinStyle:      camelJoinStyle,
 	InitialCase:    strings.Title,
 	SubsequentCase: strings.Title,
 	Example:        "UpperCamelCase",
 }
 
-var LowerCamelCaseKeepCaps = CaseConvention{
+var LowerCamelCaseKeepCaps = &CaseConvention{
 	JoinStyle:      camelJoinStyle,
 	InitialCase:    strings.ToLower,
 	SubsequentCase: strings.Title,

--- a/varcaser/varcaser_test.go
+++ b/varcaser/varcaser_test.go
@@ -33,7 +33,7 @@ func TestCamelSplitMixedUp(t *testing.T) {
 }
 
 func TestCaserSimple(t *testing.T) {
-	c := Caser{From: LowerSnakeCase, To: UpperCamelCase}
+	c := &Caser{From: LowerSnakeCase, To: UpperCamelCase}
 
 	specimen := c.String("my_int_var_20")
 	expected := "MyIntVar20"
@@ -50,7 +50,7 @@ func TestCaserLeadingUnderscoreToCamel(t *testing.T) {
 
 	// This could be supported, but for the nonce I'm going to assume YAGNI.
 
-	c := Caser{From: LowerSnakeCase, To: UpperCamelCase}
+	c := &Caser{From: LowerSnakeCase, To: UpperCamelCase}
 
 	specimen := c.String("_private_method")
 	expected := "PrivateMethod" // NOT "_PrivateMethod"
@@ -58,7 +58,7 @@ func TestCaserLeadingUnderscoreToCamel(t *testing.T) {
 }
 
 func TestCaserLeadingUnderscoreToSnake(t *testing.T) {
-	c := Caser{From: LowerSnakeCase, To: ScreamingSnakeCase}
+	c := &Caser{From: LowerSnakeCase, To: ScreamingSnakeCase}
 
 	specimen := c.String("_private_method")
 	expected := "_PRIVATE_METHOD"
@@ -66,7 +66,7 @@ func TestCaserLeadingUnderscoreToSnake(t *testing.T) {
 }
 
 func TestCaserCamelToKebab(t *testing.T) {
-	c := Caser{From: UpperCamelCase, To: KebabCase}
+	c := &Caser{From: UpperCamelCase, To: KebabCase}
 
 	specimen := c.String("SomeInitMethod")
 	expected := "some-init-method"
@@ -74,7 +74,7 @@ func TestCaserCamelToKebab(t *testing.T) {
 }
 
 func TestCaserSnakeToUpperKebab(t *testing.T) {
-	c := Caser{From: LowerSnakeCase, To: UpperKebabCase}
+	c := &Caser{From: LowerSnakeCase, To: UpperKebabCase}
 
 	specimen := c.String("some_init_method")
 	expected := "Some-Init-Method"
@@ -82,7 +82,7 @@ func TestCaserSnakeToUpperKebab(t *testing.T) {
 }
 
 func TestCaserSnakeToScreamingKebab(t *testing.T) {
-	c := Caser{From: LowerSnakeCase, To: ScreamingKebabCase}
+	c := &Caser{From: LowerSnakeCase, To: ScreamingKebabCase}
 
 	specimen := c.String("some_init_method")
 	expected := "SOME-INIT-METHOD"
@@ -91,7 +91,7 @@ func TestCaserSnakeToScreamingKebab(t *testing.T) {
 
 // AsyncHTTPRequest -> AsyncHttpRequest
 func TestCaserCamelToCamelLoseCapitals(t *testing.T) {
-	c := Caser{From: UpperCamelCase, To: UpperCamelCase}
+	c := &Caser{From: UpperCamelCase, To: UpperCamelCase}
 
 	specimen := c.String("AsyncHTTPRequest")
 	expected := "AsyncHttpRequest"
@@ -100,7 +100,7 @@ func TestCaserCamelToCamelLoseCapitals(t *testing.T) {
 
 // AsyncHTTPRequest -> AsyncHttpRequest
 func TestCaserCamelToCamelKeepCapitals(t *testing.T) {
-	c := Caser{From: UpperCamelCase, To: UpperCamelCaseKeepCaps}
+	c := &Caser{From: UpperCamelCase, To: UpperCamelCaseKeepCaps}
 
 	specimen := c.String("AsyncHTTPRequest")
 	expected := "AsyncHTTPRequest"
@@ -109,7 +109,7 @@ func TestCaserCamelToCamelKeepCapitals(t *testing.T) {
 
 // AsyncHTTPRequest -> AsyncHttpRequest
 func TestCaserCamelToHttpCase(t *testing.T) {
-	c := Caser{From: UpperCamelCase, To: HttpHeaderCase}
+	c := &Caser{From: UpperCamelCase, To: HttpHeaderCase}
 
 	specimen := c.String("AcceptEncoding")
 	expected := "Accept-Encoding"
@@ -120,14 +120,14 @@ func TestCaserLowerCamelInitialCapital(t *testing.T) {
 	// This is another tricky case. I decided that the initial Capital does
 	// NOT indicate a hidden initial separator, but that might change.
 
-	c := Caser{From: LowerCamelCase, To: KebabCase}
+	c := &Caser{From: LowerCamelCase, To: KebabCase}
 	specimen := c.String("SomeInitMethod")
 	expected := "some-init-method" // NOT "-some-init-method"
 	AssertEqual(specimen, expected, t)
 }
 
 func TestCaserIsATransformer(t *testing.T) {
-	c := transform.Transformer(Caser{From: LowerCamelCase, To: KebabCase})
+	c := transform.Transformer(&Caser{From: LowerCamelCase, To: KebabCase})
 	dst := make([]byte, 20)
 	src := [20]byte{}
 	copy(src[:], "oneMeasleyVariable")


### PR DESCRIPTION
# Introduction
Previous implementation of Varcaser uses objects instead of pointers. It makes program to copy non-small objects every time any method is called. For example, Caser objects include ~9 fields in depth to copy always.
# Problem
It is a lot of wasting time to copy objects.
# Solution
Use pointer like in the PR :)
# Notes
The solution can be incompatible with previous code-usages.